### PR TITLE
add ICE to server

### DIFF
--- a/webrtc_ros/CMakeLists.txt
+++ b/webrtc_ros/CMakeLists.txt
@@ -35,7 +35,14 @@ catkin_package(
     image_transport
     nodelet
     roscpp
+    message_runtime
+    std_msgs
   DEPENDS webrtc
+)
+
+catkin_install_python(
+    PROGRAMS src/ice_server_service.py
+    DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 
 ###########

--- a/webrtc_ros/CMakeLists.txt
+++ b/webrtc_ros/CMakeLists.txt
@@ -7,9 +7,26 @@ find_package(catkin REQUIRED COMPONENTS
   image_transport
   nodelet
   roscpp
+  std_msgs
+  message_generation
 )
 find_package(webrtc REQUIRED)
 find_package(X11 REQUIRED)
+
+add_message_files(
+    FILES
+    IceServer.msg
+)
+
+add_service_files(
+    FILES
+    GetIceServers.srv
+)
+
+generate_messages(
+    DEPENDENCIES
+    std_msgs
+)
 
 catkin_package(
   CATKIN_DEPENDS

--- a/webrtc_ros/launch/webrtc_ros.launch
+++ b/webrtc_ros/launch/webrtc_ros.launch
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+<launch>
+  <!--ICE servers are used to resolve remote connections over the internet. If you-->
+  <!--are in a single network where the devices can find each other by IP address,-->
+  <!--this is not needed:-->
+  <node name="ice_server_provider" pkg="webrtc_ros" type="ice_server_service.py">
+    <!--These are the servers used for resolving remote addresses, google provides-->
+    <!--some free to use ones, here as defaults. You could setup your own or use-->
+    <!--another provider-->
+    <rosparam param="stun_servers">
+          ['stun:stun1.l.google.com:19302', 'stun:stun2.l.google.com:19302']
+    </rosparam>
+    <!--Turn servers are used to route traffic from behind challenging networks.-->
+    <!--Not always needed, but in some corporate environments it might be. -->
+    <!--This is the url of the turn server (Ex: coturn)-->
+    <rosparam param="turn_server_uris">
+        []
+    </rosparam>
+    <!--You need credentials to access your turn server. The best way to do-->
+    <!--that (the way we support) is to use a seperate rest api with a shared-->
+    <!--secret with coturn. This is the uri, username, and password that will -->
+    <!--be passed to that endpoint. They will be passed to the enpoint as a -->
+    <!--post request with fields username and password in the request body-->
+    <!--It expects the server to respond with the username and password for-->
+    <!--the turn server in fields username and password held in the response-->
+    <!--data-->
+    <param name="turn_server_creds_uri" value=""/>
+    <param name="turn_server_creds_username" value=""/>
+    <param name="turn_server_creds_password" value=""/>
+  </node>
+  <node name="webrtc_server" pkg="webrtc_ros" type="webrtc_ros_server_node">
+    <param name="port" value="9090"/>
+  </node>
+</launch>

--- a/webrtc_ros/msg/IceServer.msg
+++ b/webrtc_ros/msg/IceServer.msg
@@ -1,0 +1,3 @@
+string uri
+string username
+string password

--- a/webrtc_ros/package.xml
+++ b/webrtc_ros/package.xml
@@ -22,6 +22,14 @@
   <depend>nodelet</depend>
   <depend>async_web_server_cpp</depend>
 
+  <build_export_depend>message_runtime</build_export_depend>
+
+  <build_depend>message_generation</build_depend>
+
+  <build_depend>std_msgs</build_depend>
+  <build_export_depend>std_msgs</build_export_depend>
+  <exec_depend>std_msgs</exec_depend>
+
   <export>
     <nodelet plugin="${prefix}/nodelet_plugins.xml" />
   </export>

--- a/webrtc_ros/src/ice_server_service.py
+++ b/webrtc_ros/src/ice_server_service.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+
+import json
+import rospy
+import requests
+from webrtc_ros.msg import IceServer
+from webrtc_ros.srv import GetIceServers, GetIceServersResponse
+
+
+class IceServerManager(object):
+    """ Manages providing ice server information to the webrtc system """
+
+    def __init__(self):
+        rospy.init_node('ice_server_provider')
+
+        self.stun_servers = rospy.get_param('stun_servers', [
+            'stun:stun1.l.google.com:19302', 'stun:stun2.l.google.com:19302'])
+        self.turn_server_uris = rospy.get_param('turn_server_uris', '')
+        self.turn_creds_uri = rospy.get_param('turn_server_creds_uri', '')
+        self.turn_creds_username = rospy.get_param(
+            'turn_server_creds_username', '')
+        self.turn_creds_password = rospy.get_param(
+            'turn_server_creds_password', '')
+
+        self.get_ice_servers_service = rospy.Service(
+            'get_ice_servers', GetIceServers, self.get_ice_servers)
+
+        rospy.loginfo('Ice Server Provider Up')
+        rospy.spin()
+
+    def get_turn_creds(self):
+        """Get the credentials from the turn server."""
+        if self.turn_creds_uri:
+            resp = requests.post(self.turn_creds_uri,
+                                 {'username': self.turn_creds_username,
+                                  'password':  self.turn_creds_password})
+            if(('username' in resp.data) and ('password' in resp.data)):
+                return resp.data
+        return False
+
+    def get_ice_servers(self, _):
+        """Callback for service. Returns the ice servers"""
+        resp = GetIceServersResponse()
+        turn_creds = self.get_turn_creds()
+        if turn_creds:
+            for uri in self.turn_server_uris:
+                serv = IceServer()
+                serv.username = turn_creds['username']
+                serv.password = turn_creds['password']
+                resp.servers.append(serv)
+        for suri in self.stun_servers:
+            serv = IceServer()
+            serv.uri = suri
+            resp.servers.append(serv)
+        return resp
+
+
+if __name__ == '__main__':
+    IceServerManager()

--- a/webrtc_ros/src/webrtc_client.cpp
+++ b/webrtc_ros/src/webrtc_client.cpp
@@ -112,11 +112,18 @@ bool WebrtcClient::initPeerConnection()
   }
   if (!peer_connection_)
   {
-    webrtc::PeerConnectionInterface::IceServers servers;
+    webrtc::PeerConnectionInterface::IceServer server1;
+    server1.uri = "stun:stun1.l.google.com:19302";
+    webrtc::PeerConnectionInterface::IceServer server2;
+    server2.uri = "stun:stun2.l.google.com:19302";
+    webrtc::PeerConnectionInterface::RTCConfiguration config;
+    config.servers.push_back(server1);
+    config.servers.push_back(server2);
+
     WebrtcClientWeakPtr weak_this(keep_alive_this_);
     webrtc_observer_proxy_ = new rtc::RefCountedObject<WebrtcClientObserverProxy>(weak_this);
     peer_connection_ = peer_connection_factory_->CreatePeerConnection(
-            webrtc::PeerConnectionInterface::RTCConfiguration(),
+            config,
             nullptr,
             nullptr,
             webrtc_observer_proxy_.get()

--- a/webrtc_ros/srv/GetIceServers.srv
+++ b/webrtc_ros/srv/GetIceServers.srv
@@ -1,0 +1,4 @@
+## args
+---
+## Resp
+IceServer[] servers


### PR DESCRIPTION
In reference to #39 and #24. This adds the default google stun servers. Combined with something like [this](https://github.com/Rehab-Robotics-Lab/LilFloSystem/blob/88f220c4463899fc519eb0707039ad8cf0ddf560/flo_web/web_app/src/components/robotControl/Vids.tsx#L51) You can get the system to work over the web in most situations. 

I'm putting this in as a draft for now. Hardcoding in the stun servers is probably not what anyone wants. I also don't have TURN in there yet. I think for TURN what I am going to do is allow users to specify a service to call to get TURN credentials via whatever means the user asks for (REST, permanent, etc.). I will allow a flag to be passed into the webrtc server nodes whether to use that or not. 

The alternative would be to pass all of the ICE info from the client to the server through the existing messaging architecture. That actually seems nicer for my applications, but quite a bit harder to implement and not as flexible for other users.

Let me know your thoughts.

A few important links:
- [ICE Server Defs](https://webrtc.googlesource.com/src/+/refs/heads/master/api/peer_connection_interface.h#206)
- [Example using ICE Servers in browser level WebRTC](https://webrtc.googlesource.com/src/+/refs/heads/master/examples/peerconnection/client/conductor.cc#178)
- [How the example gets its stun def](https://webrtc.googlesource.com/src/+/refs/heads/master/examples/peerconnection/client/defaults.cc#41)