### PR TITLE
Fix errors in turn credential generation

### DIFF
--- a/webrtc_ros/scripts/ice_server_service.py
+++ b/webrtc_ros/scripts/ice_server_service.py
@@ -45,6 +45,7 @@ class IceServerManager(object):
         if turn_creds:
             for uri in self.turn_server_uris:
                 serv = IceServer()
+                serv.uri = uri
                 serv.username = turn_creds['username']
                 serv.password = turn_creds['password']
                 resp.servers.append(serv)

--- a/webrtc_ros/scripts/ice_server_service.py
+++ b/webrtc_ros/scripts/ice_server_service.py
@@ -13,14 +13,14 @@ class IceServerManager(object):
     def __init__(self):
         rospy.init_node('ice_server_provider')
 
-        self.stun_servers = rospy.get_param('stun_servers', [
+        self.stun_servers = rospy.get_param('~stun_servers', [
             'stun:stun1.l.google.com:19302', 'stun:stun2.l.google.com:19302'])
-        self.turn_server_uris = rospy.get_param('turn_server_uris', '')
-        self.turn_creds_uri = rospy.get_param('turn_server_creds_uri', '')
+        self.turn_server_uris = rospy.get_param('~turn_server_uris', '')
+        self.turn_creds_uri = rospy.get_param('~turn_server_creds_uri', '')
         self.turn_creds_username = rospy.get_param(
-            'turn_server_creds_username', '')
+            '~turn_server_creds_username', '')
         self.turn_creds_password = rospy.get_param(
-            'turn_server_creds_password', '')
+            '~turn_server_creds_password', '')
 
         self.get_ice_servers_service = rospy.Service(
             'get_ice_servers', GetIceServers, self.get_ice_servers)

--- a/webrtc_ros/scripts/ice_server_service.py
+++ b/webrtc_ros/scripts/ice_server_service.py
@@ -31,11 +31,24 @@ class IceServerManager(object):
     def get_turn_creds(self):
         """Get the credentials from the turn server."""
         if self.turn_creds_uri:
+            rospy.logdebug('getting turn server credentials')
             resp = requests.post(self.turn_creds_uri,
                                  {'username': self.turn_creds_username,
                                   'password':  self.turn_creds_password})
-            if(('username' in resp.data) and ('password' in resp.data)):
-                return resp.data
+            try:
+                rospy.loginfo('trying to parse response from server')
+                data = resp.json()
+                if('username' in data and 'password' in data):
+                    rospy.loginfo('succesfully received turn credentials')
+                    return data
+                rospy.logwarn(
+                    'response did not have username and password fields')
+            except AttributeError:
+                rospy.logerr(
+                    'server did not respond with JSON, response code: %i',
+                    resp.status_code)
+        else:
+            rospy.logdebug('No uri provided for turn credentials')
         return False
 
     def get_ice_servers(self, _):


### PR DESCRIPTION
Apparently the method I was using for testing was not sufficient and the code to actually get the turn credentials didn't work. This has been further tested. I changed the parameters to be private, fixed up the api call, and added some logging to help future users. 