### PR TITLE
Fix/ros2 jazzy

### DIFF
--- a/webrtc/build/get_gn
+++ b/webrtc/build/get_gn
@@ -25,7 +25,7 @@ then
 	git clone https://gn.googlesource.com/gn third_party/gn
 	cd third_party/gn
 	git checkout 501b49a3ab4f0d099457b6e5b62c709a1d2311be
-	CC=gcc CXX=g++ LDFLAGS=-fuse-ld=gold python build/gen.py
+	CC=gcc CXX=g++ LDFLAGS=-fuse-ld=gold python3 build/gen.py
 	"$rootdir/depot_tools/ninja" -C out gn
 	cp out/gn .
 fi

--- a/webrtc_ros/CMakeLists.txt
+++ b/webrtc_ros/CMakeLists.txt
@@ -11,6 +11,7 @@ find_package(webrtc_ros_msgs REQUIRED)
 find_package(webrtc REQUIRED)
 find_package(X11 REQUIRED)
 find_package(jsoncpp REQUIRED)
+find_package(OpenCV REQUIRED)
 
 
 ###########
@@ -23,7 +24,7 @@ include_directories(
   ${OpenCV_INCLUDE_DIRS}
   ${webrtc_ros_msgs_INCLUDE_DIRS}
   ${webrtc_INCLUDE_DIRS}
-  
+
 )
 add_definitions(${webrtc_DEFINITIONS})
 
@@ -56,8 +57,8 @@ ament_target_dependencies(
     image_transport
     rclcpp
     std_msgs
-    webrtc_ros_msgs
-    
+    webrtc_ros_msgs    
+
 )
 
 target_link_libraries(${PROJECT_NAME}_server_node 
@@ -65,6 +66,8 @@ target_link_libraries(${PROJECT_NAME}_server_node
   webrtc
   jsoncpp_lib
   ${X11_LIBRARIES}
+  ${OpenCV_LIBS}
+  ament_index_cpp::ament_index_cpp
 )
 
 set_target_properties(${PROJECT_NAME}_server_node PROPERTIES COMPILE_OPTIONS "-std=c++17")

--- a/webrtc_ros/include/webrtc_ros/ros_video_capturer.h
+++ b/webrtc_ros/include/webrtc_ros/ros_video_capturer.h
@@ -37,7 +37,7 @@ public:
 	bool remote() const override;
 
 private:
-  RTC_DISALLOW_COPY_AND_ASSIGN(RosVideoCapturer);
+  // RTC_DISALLOW_COPY_AND_ASSIGN(RosVideoCapturer);
   boost::shared_ptr<RosVideoCapturerImpl> impl_;
 };
 
@@ -56,7 +56,7 @@ public:
   void Stop();
 
 private:
-  RTC_DISALLOW_COPY_AND_ASSIGN(RosVideoCapturerImpl);
+  // RTC_DISALLOW_COPY_AND_ASSIGN(RosVideoCapturerImpl);
 
   ImageTransportFactory it_;
   const std::string topic_, transport_;

--- a/webrtc_ros/include/webrtc_ros/ros_video_capturer.h
+++ b/webrtc_ros/include/webrtc_ros/ros_video_capturer.h
@@ -37,7 +37,9 @@ public:
 	bool remote() const override;
 
 private:
-  // RTC_DISALLOW_COPY_AND_ASSIGN(RosVideoCapturer);
+  RosVideoCapturer(const RosVideoCapturer&) = delete;
+  RosVideoCapturer& operator=(const RosVideoCapturer&) = delete;
+
   boost::shared_ptr<RosVideoCapturerImpl> impl_;
 };
 
@@ -56,7 +58,8 @@ public:
   void Stop();
 
 private:
-  // RTC_DISALLOW_COPY_AND_ASSIGN(RosVideoCapturerImpl);
+  RosVideoCapturerImpl(const RosVideoCapturerImpl&) = delete;
+  RosVideoCapturerImpl& operator=(const RosVideoCapturerImpl&) = delete;
 
   ImageTransportFactory it_;
   const std::string topic_, transport_;

--- a/webrtc_ros/include/webrtc_ros/ros_video_renderer.h
+++ b/webrtc_ros/include/webrtc_ros/ros_video_renderer.h
@@ -16,7 +16,8 @@ public:
   virtual void OnFrame(const webrtc::VideoFrame& frame) override;
 
 private:
-  // RTC_DISALLOW_COPY_AND_ASSIGN(RosVideoRenderer);
+  RosVideoRenderer(const RosVideoRenderer&) = delete;
+  RosVideoRenderer& operator=(const RosVideoRenderer&) = delete;
   std::shared_ptr<image_transport::ImageTransport> it_;
   const std::string topic_;
   image_transport::Publisher pub_;

--- a/webrtc_ros/include/webrtc_ros/ros_video_renderer.h
+++ b/webrtc_ros/include/webrtc_ros/ros_video_renderer.h
@@ -16,7 +16,7 @@ public:
   virtual void OnFrame(const webrtc::VideoFrame& frame) override;
 
 private:
-  RTC_DISALLOW_COPY_AND_ASSIGN(RosVideoRenderer);
+  // RTC_DISALLOW_COPY_AND_ASSIGN(RosVideoRenderer);
   std::shared_ptr<image_transport::ImageTransport> it_;
   const std::string topic_;
   image_transport::Publisher pub_;

--- a/webrtc_ros/src/ros_video_capturer.cpp
+++ b/webrtc_ros/src/ros_video_capturer.cpp
@@ -1,8 +1,7 @@
 #include "webrtc_ros/ros_video_capturer.h"
-#include "webrtc/rtc_base/bind.h"
 
 #include <rclcpp/rclcpp.hpp>
-#include <cv_bridge/cv_bridge.h>
+#include <cv_bridge/cv_bridge.hpp>
 #include <boost/enable_shared_from_this.hpp>
 
 namespace webrtc_ros

--- a/webrtc_ros/src/ros_video_renderer.cpp
+++ b/webrtc_ros/src/ros_video_renderer.cpp
@@ -1,6 +1,6 @@
 #include <webrtc_ros/ros_video_renderer.h>
 #include <rclcpp/rclcpp.hpp>
-#include <cv_bridge/cv_bridge.h>
+#include <cv_bridge/cv_bridge.hpp>
 #include <webrtc/3rdparty/libyuv/convert_from.h>
 
 namespace webrtc_ros

--- a/webrtc_ros/src/webrtc_client.cpp
+++ b/webrtc_ros/src/webrtc_client.cpp
@@ -5,7 +5,6 @@
 #include <webrtc_ros/ice_candidate_message.h>
 //#include "talk/media/devices/devicemanager.h"
 #include <webrtc/api/video/video_source_interface.h>
-#include <webrtc/rtc_base/bind.h>
 #include <webrtc_ros/ros_video_capturer.h>
 #include <webrtc_ros_msgs/srv/get_ice_servers.hpp>
 
@@ -177,8 +176,7 @@ public:
   {
     WebrtcClientPtr _this = weak_this_.lock();
     if (_this)
-      _this->signaling_thread_->Invoke<void>(RTC_FROM_HERE, rtc::Bind(&WebrtcClient::handle_message,
-						       _this.get(), type, raw));
+      _this->signaling_thread_->BlockingCall([t = _this.get(), type, raw] { t->handle_message(type, raw); });
   }
 private:
   WebrtcClientWeakPtr weak_this_;
@@ -285,7 +283,7 @@ void WebrtcClient::handle_message(MessageHandler::Type type, const std::string& 
 
                     rtc::scoped_refptr<webrtc::MediaStreamInterface> stream = peer_connection_factory_->CreateLocalMediaStream(stream_id);
 
-                    if (!peer_connection_->AddStream(stream))
+                    if (!peer_connection_->AddStream(stream.get()))
                     {
                       RCLCPP_WARN(nh_->get_logger(), "Adding stream to PeerConnection failed");
                 continue;
@@ -300,7 +298,7 @@ void WebrtcClient::handle_message(MessageHandler::Type type, const std::string& 
                 RCLCPP_WARN_STREAM(nh_->get_logger(), "Stream not found with id: " << stream_id);
                 continue;
               }
-                    peer_connection_->RemoveStream(stream);
+                    peer_connection_->RemoveStream(stream.get());
             }
             else if(action.type == ConfigureAction::kAddVideoTrackActionName) {
               FIND_PROPERTY_OR_CONTINUE("stream_id", stream_id);
@@ -326,7 +324,7 @@ void WebrtcClient::handle_message(MessageHandler::Type type, const std::string& 
                       rtc::scoped_refptr<webrtc::VideoTrackInterface> video_track(
                         peer_connection_factory_->CreateVideoTrack(
                           track_id,
-                          capturer));
+                          capturer.get()));
                       stream->AddTrack(video_track);
                       capturer->Start();
               }
@@ -356,10 +354,9 @@ void WebrtcClient::handle_message(MessageHandler::Type type, const std::string& 
               if(audio_type == "local") {
                 cricket::AudioOptions options;
                 rtc::scoped_refptr<webrtc::AudioTrackInterface> audio_track(
-                  peer_connection_factory_->CreateAudioTrack(
-                    track_id,
-              peer_connection_factory_->CreateAudioSource(options)));
-                      stream->AddTrack(audio_track);
+                    peer_connection_factory_->CreateAudioTrack(track_id, peer_connection_factory_->CreateAudioSource(options).get())
+                );
+                stream->AddTrack(audio_track);
               }
               else {
                 RCLCPP_WARN_STREAM(nh_->get_logger(), "Unknown video source type: " << audio_type);
@@ -416,7 +413,7 @@ void WebrtcClient::handle_message(MessageHandler::Type type, const std::string& 
 
       RCLCPP_DEBUG_STREAM(nh_->get_logger(), "Received remote description: " << message.sdp);
       rtc::scoped_refptr<DummySetSessionDescriptionObserver> dummy_set_description_observer(new rtc::RefCountedObject<DummySetSessionDescriptionObserver>());
-      peer_connection_->SetRemoteDescription(dummy_set_description_observer, session_description);
+      peer_connection_->SetRemoteDescription(dummy_set_description_observer.get(), session_description);
     }
     else if (IceCandidateMessage::isIceCandidate(message_json))
     {
@@ -465,7 +462,7 @@ void WebrtcClient::handle_message(MessageHandler::Type type, const std::string& 
 void WebrtcClient::OnSessionDescriptionSuccess(webrtc::SessionDescriptionInterface* description)
 {
   rtc::scoped_refptr<DummySetSessionDescriptionObserver> dummy_set_description_observer(new rtc::RefCountedObject<DummySetSessionDescriptionObserver>());
-  peer_connection_->SetLocalDescription(dummy_set_description_observer, description);
+  peer_connection_->SetLocalDescription(dummy_set_description_observer.get(), description);
 
   SdpMessage message;
   if (message.fromSessionDescription(*description))

--- a/webrtc_ros/src/webrtc_ros_server.cpp
+++ b/webrtc_ros/src/webrtc_ros_server.cpp
@@ -2,15 +2,16 @@
 #include <webrtc_ros/webrtc_ros_server.h>
 #include "webrtc/rtc_base/ssl_adapter.h"
 
-#include "webrtc/rtc_base/bind.h"
-
 namespace webrtc_ros
 {
 
 MessageHandler* WebrtcRosServer_handle_new_signaling_channel(void* _this, SignalingChannel *channel)
 {
-    return ((WebrtcRosServer*) _this)->signaling_thread_->Invoke<MessageHandler*>(RTC_FROM_HERE, rtc::Bind(&WebrtcRosServer::handle_new_signaling_channel,
-            (WebrtcRosServer*)_this, channel));
+    MessageHandler* result;
+    ((WebrtcRosServer*) _this)->signaling_thread_->BlockingCall( 
+        [&]{ result = ((WebrtcRosServer*) _this)->handle_new_signaling_channel(channel);}
+    );
+    return result;
 }
 
 WebrtcRosServer::WebrtcRosServer(rclcpp::Node::SharedPtr nh)


### PR DESCRIPTION
**Public API Changes**
None

**Description**
Get build to work on Ros2 Jazzy, Ubuntu 24.04.

There are some diffs applied to the cloned webrtc source code (first two bullet points below) I'm not sure how to best apply them in this PR. Maybe apply a patch after pulling the code or something... 

Open problems: 
- [ ] `webrtc/build/webrtc/src/rtc_base/third_party/base64/base64.h`: add `#include <cstdint>`
- [ ] `webrtc/build/webrtc/src/build/util/lastchange.py`: replace `utcfromtimestamp` with `fromtimestamp` on L318
- [x] I could not find a proper replacement for the `RTC_DISALLOW_COPY_AND_ASSIGN` macro, so currently it's commented out. **Edit**: Found it and fixed.
- [ ] Currently I cloned `vision_opencv` and checked out `7a47d35`, and renamed a few .h to .hpp - I'm not sure if that's needed though, and I forgot where I read that this is required. Edit: yeah, seems to be needed.
<!-- Link relevant GitHub issues -->
#71 

After launching:
The webserver launches fine and shows the available topics:
![image](https://github.com/user-attachments/assets/7e079d02-8c2e-40bd-b2e1-b05a7f81d144)


But when trying to establish a connection, it crashes.

```bash
[webrtc_ros_server_node-2] [INFO] [1720796065.255299670] [webrtc_server]: JSON: {"type":"configure","actions":[{"type":"add_stream","id":"webrtc_ros-stream-975963065"},{"type":"add_video_track","stream_id":"webrtc_ros-stream-975963065","id":"webrtc_ros-stream-975963065/subscribed_video","src":"ros_image:/optical_camera_rear/image_raw"}]}
[webrtc_ros_server_node-2] 
[webrtc_ros_server_node-2] 
[webrtc_ros_server_node-2] #
[webrtc_ros_server_node-2] # Fatal error in: ../../../src/webrtc_ros/webrtc/build/webrtc/src/pc/peer_connection.cc, line 816
[webrtc_ros_server_node-2] # last system error: 0
[webrtc_ros_server_node-2] # Check failed: !IsUnifiedPlan()
[ERROR] [webrtc_ros_server_node-2]: process has died [pid 382174, exit code -6, cmd '/home/er/ros2_ws/install/webrtc_ros/lib/webrtc_ros/webrtc_ros_server_node --ros-args -r __node:=webrtc_server --params-file /tmp/launch_params_y3ih5v_0'].
[webrtc_ros_server_node-2] # AddStream is not available with Unified Plan SdpSemantics. Please use AddTrack instead.
```
Looks like Unified Plan semantics deprecated a few of the older APIs and the webrtc client need to be rewritten...
https://webrtc.org/getting-started/unified-plan-transition-guide
There's a document on how to migrate native C++ applications to Unified Plan, but I can't access the doc...
I found this page that maybe (?) contains a copy of the document https://blog.csdn.net/dotphoenix/article/details/107480133 but no idea.